### PR TITLE
Update the pipeline to create image specific entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,5 +72,5 @@ jobs:
       script:
         - |
           make init
-          make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+          ${TRAVIS_BUILD_DIR}/build/pipeline.sh
 

--- a/build/pipeline.sh
+++ b/build/pipeline.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Pipeline for certificate manager starting : $(date)"
+for PROJECT in `ls cmd`; do
+	export PROJECT
+	echo "Begin pipeline for cert-manager $PROJECT"
+	export DOCKER_IMAGE=cert-manager-$PROJECT
+	export COMPONENT_NAME=$(cat COMPONENT_NAME 2> /dev/null)-$PROJECT
+	export COMPONENT_VERSION=$(cat COMPONENT_VERSION 2> /dev/null)
+	export COMPONENT_DOCKER_REPO="quay.io/open-cluster-management"
+	export DOCKER_IMAGE_AND_TAG=${COMPONENT_DOCKER_REPO}/${COMPONENT_NAME}:${COMPONENT_VERSION}${COMPONENT_TAG_EXTENSION}
+	make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+	echo "Completed pipeline for cert-manager $PROJECT"
+done
+echo "Pipeline for certificate manager completed : $(date)"


### PR DESCRIPTION
Cert-manager creates four images from one repository.  Those image need to be updated properly
in the CICD pipeline.  The pipeline command needs some customization so it works with each of the images.
This is a first attempt to try to make it work the same way the build creates the 4 images.