### PR TITLE
Merge latest change to the release branch

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -29,6 +29,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -489,7 +490,8 @@ func (c *controller) updateSecret(ctx context.Context, crt *v1alpha1.Certificate
 
 	// if it is a new resource
 	if secret.SelfLink == "" {
-		if c.addOwnerReferences {
+		// ACM Uninstall support - OWNED_NAMESPACE is set to ACM install namespace
+		if c.addOwnerReferences || namespace == os.Getenv("OWNED_NAMESPACE") {
 			secret.SetOwnerReferences(append(secret.GetOwnerReferences(), ownerRef(crt)))
 		}
 		secret, err = c.kClient.CoreV1().Secrets(namespace).Create(secret)


### PR DESCRIPTION

**What this PR does / why we need it**:
This is the secret removal undo.  It has a change that will still allow secret removal for a configured namespace.