### PR TITLE
first try at setting an owner reference for the leader election cm

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -303,7 +303,7 @@ func startLeaderElection(ctx context.Context, opts *options.ControllerOptions, l
 		ConfigMapMeta: metav1.ObjectMeta{
 			Namespace:       opts.LeaderElectionNamespace,
 			Name:            "cert-manager-controller",
-			OwnerReferences: []metav1.OwnerReference{ owner, },
+			OwnerReferences: []metav1.OwnerReference{owner},
 		},
 		Client: leaderElectionClient.CoreV1(),
 		LockConfig: resourcelock.ResourceLockConfig{


### PR DESCRIPTION

**What this PR does / why we need it**:
The goal here is to add some cleanup to cert-manager so pieces that are being left behind after uninstall get cleaned up automatically.   Using an owner reference to attempt this.

**Which issue this PR fixes** 
https://github.com/open-cluster-management/backlog/issues/787

