### PR TITLE
remove gosec quiet option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ go-coverage:
 			grep -v '/third_party' | \
 			grep -v '/docs/' \
 		) > report.json)
-	gosec --quiet -fmt sonarqube -out gosec.json -no-fail ./...
+	gosec -fmt sonarqube -out gosec.json -no-fail ./...
 	sonar-scanner --debug || echo "Sonar scanner is not available"
 
 go-fmt:


### PR DESCRIPTION

**What this PR does / why we need it**:
The quiet option on gosec will cause issues when you fix all of the security issues that are found.

