### PR TITLE
adjust how the user is accessing the binary and tmp directory

### DIFF
--- a/hack/build/dockerfiles/webhook/Dockerfile
+++ b/hack/build/dockerfiles/webhook/Dockerfile
@@ -18,13 +18,13 @@ RUN mkdir licenses
 
 COPY LICENSE licenses
 
-WORKDIR /home/webhook
 USER 100101
 
-RUN mkdir bin tmp
-ADD cert-manager-webhook_linux_$GOARCH bin/webhook
+WORKDIR /tmp
+RUN mkdir tmp
+ADD cert-manager-webhook_linux_$GOARCH /usr/bin/webhook
 
-ENTRYPOINT ["bin/webhook"]
+ENTRYPOINT ["/usr/bin/webhook"]
 
 # http://label-schema.org/rc1/
 LABEL org.label-schema.vendor="Red Hat" \


### PR DESCRIPTION

**What this PR does / why we need it**:

Fix a problem seen using OCP 4.6.10 where the container does not start.  The error is:
```
Error: container create failed: time="2021-01-14T14:17:42Z" level=error msg="container_linux.go:366: starting container process caused: chdir to cwd (\"/home/webhook\") set in config.json failed: permission denied"
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1915503
Issue: https://github.com/open-cluster-management/backlog/issues/8493