### PR TITLE
backport fix that allows binary to run from /usr/bin

### DIFF
--- a/hack/build/dockerfiles/webhook/Dockerfile
+++ b/hack/build/dockerfiles/webhook/Dockerfile
@@ -18,13 +18,13 @@ RUN mkdir licenses
 
 COPY LICENSE licenses
 
-WORKDIR /home/webhook
 USER 100101
 
-RUN mkdir bin tmp
-ADD cert-manager-webhook_linux_$GOARCH bin/webhook
+WORKDIR /tmp
+RUN mkdir tmp
+ADD cert-manager-webhook_linux_$GOARCH /usr/bin/webhook
 
-ENTRYPOINT ["bin/webhook"]
+ENTRYPOINT ["/usr/bin/webhook"]
 
 # http://label-schema.org/rc1/
 LABEL org.label-schema.vendor="Red Hat" \


### PR DESCRIPTION

**What this PR does / why we need it**:
Backport of fix that resolves an OCP problem seen with OCP 4.6.10 which is supported with ACM 2.1.x

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that fixes original issue: https://github.com/open-cluster-management/backlog/issues/8493
backport to 2.1 issue: https://github.com/open-cluster-management/backlog/issues/8517

**Special notes for your reviewer**:
None, I'll work on a downstream fix too.

**Release note**:
Release notes will be added to https://github.com/open-cluster-management/backlog/issues/8517
