### PR TITLE
change selflink to resourceversion

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -492,7 +492,7 @@ func (c *controller) updateSecret(ctx context.Context, crt *v1alpha1.Certificate
 	secret.Data[v1alpha1.TLSCAKey] = ca
 
 	// if it is a new resource
-	if secret.SelfLink == "" {
+	if secret.ResourceVersion == "" {
 		// ACM Uninstall support - OWNED_NAMESPACE is set to ACM install namespace
 		if c.addOwnerReferences || namespace == os.Getenv("OWNED_NAMESPACE") {
 			secret.SetOwnerReferences(append(secret.GetOwnerReferences(), ownerRef(crt)))

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -273,9 +273,9 @@ func TestSync(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: gen.DefaultTestNamespace,
-							Name:      "output",
-							SelfLink:  "abc",
+							Namespace:       gen.DefaultTestNamespace,
+							Name:            "output",
+							ResourceVersion: "123",
 							Labels: map[string]string{
 								cmapi.CertificateNameKey: "nottest",
 							},
@@ -300,9 +300,9 @@ func TestSync(t *testing.T) {
 						gen.DefaultTestNamespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: gen.DefaultTestNamespace,
-								Name:      "output",
-								SelfLink:  "abc",
+								Namespace:       gen.DefaultTestNamespace,
+								Name:            "output",
+								ResourceVersion: "123",
 								Labels: map[string]string{
 									cmapi.CertificateNameKey: "test",
 								},
@@ -393,9 +393,9 @@ func TestSync(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: gen.DefaultTestNamespace,
-							Name:      "output",
-							SelfLink:  "abc",
+							Namespace:       gen.DefaultTestNamespace,
+							Name:            "output",
+							ResourceVersion: "123",
 							Labels: map[string]string{
 								cmapi.CertificateNameKey: "nottest",
 							},
@@ -420,9 +420,9 @@ func TestSync(t *testing.T) {
 						gen.DefaultTestNamespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: gen.DefaultTestNamespace,
-								Name:      "output",
-								SelfLink:  "abc",
+								Namespace:       gen.DefaultTestNamespace,
+								Name:            "output",
+								ResourceVersion: "123",
 								Labels: map[string]string{
 									cmapi.CertificateNameKey: "test",
 								},
@@ -461,9 +461,9 @@ func TestSync(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: gen.DefaultTestNamespace,
-							Name:      "output",
-							SelfLink:  "abc",
+							Namespace:       gen.DefaultTestNamespace,
+							Name:            "output",
+							ResourceVersion: "123",
 							Labels: map[string]string{
 								cmapi.CertificateNameKey: "nottest",
 							},
@@ -505,9 +505,9 @@ func TestSync(t *testing.T) {
 						gen.DefaultTestNamespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: gen.DefaultTestNamespace,
-								Name:      "output",
-								SelfLink:  "abc",
+								Namespace:       gen.DefaultTestNamespace,
+								Name:            "output",
+								ResourceVersion: "123",
 								Labels: map[string]string{
 									cmapi.CertificateNameKey: "test",
 								},
@@ -546,9 +546,9 @@ func TestSync(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: gen.DefaultTestNamespace,
-							Name:      "output",
-							SelfLink:  "abc",
+							Namespace:       gen.DefaultTestNamespace,
+							Name:            "output",
+							ResourceVersion: "123",
 							Labels: map[string]string{
 								cmapi.CertificateNameKey: "test",
 							},
@@ -598,9 +598,9 @@ func TestSync(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: gen.DefaultTestNamespace,
-							Name:      "output",
-							SelfLink:  "abc",
+							Namespace:       gen.DefaultTestNamespace,
+							Name:            "output",
+							ResourceVersion: "123",
 							Labels: map[string]string{
 								cmapi.CertificateNameKey: "nottest",
 							},
@@ -625,9 +625,9 @@ func TestSync(t *testing.T) {
 						gen.DefaultTestNamespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: gen.DefaultTestNamespace,
-								Name:      "output",
-								SelfLink:  "abc",
+								Namespace:       gen.DefaultTestNamespace,
+								Name:            "output",
+								ResourceVersion: "123",
 								Labels: map[string]string{
 									cmapi.CertificateNameKey: "test",
 								},
@@ -670,9 +670,9 @@ func TestSync(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: gen.DefaultTestNamespace,
-							Name:      "output",
-							SelfLink:  "abc",
+							Namespace:       gen.DefaultTestNamespace,
+							Name:            "output",
+							ResourceVersion: "123",
 							Labels: map[string]string{
 								cmapi.CertificateNameKey: "test",
 							},
@@ -713,9 +713,9 @@ func TestSync(t *testing.T) {
 						gen.DefaultTestNamespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: gen.DefaultTestNamespace,
-								Name:      "output",
-								SelfLink:  "abc",
+								Namespace:       gen.DefaultTestNamespace,
+								Name:            "output",
+								ResourceVersion: "123",
 								Labels: map[string]string{
 									cmapi.CertificateNameKey: "test",
 								},
@@ -880,7 +880,7 @@ func TestSync(t *testing.T) {
 		//				ObjectMeta: metav1.ObjectMeta{
 		//					Namespace: gen.DefaultTestNamespace,
 		//					Name:      "output",
-		//					SelfLink:  "abc",
+		//					ResourceVersion:  "123",
 		//					Labels: map[string]string{
 		//						cmapi.CertificateNameKey: "nottest",
 		//					},
@@ -909,7 +909,7 @@ func TestSync(t *testing.T) {
 		//					ObjectMeta: metav1.ObjectMeta{
 		//						Namespace: gen.DefaultTestNamespace,
 		//						Name:      "output",
-		//						SelfLink:  "abc",
+		//						ResourceVersion:  "123",
 		//						Labels: map[string]string{
 		//							cmapi.CertificateNameKey: "test",
 		//						},


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>

**What this PR does / why we need it**:
OCP/k8s has removed SelfLink.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/open-cluster-management/backlog/issues/13121

**Special notes for your reviewer**:
NA

**Release note**:
None